### PR TITLE
Group single word strings together based on file - Not Ready Yet

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -491,7 +491,8 @@ function createTranslator(
         (typeof sourceFile.content[key] == 'string' && !destinationFile?.content[key]))
       .map((key) => ({
         key,
-        value: sourceFile.type === 'key-based' ? sourceFile.content[key] : key,
+        value: sourceFile.type === 'key-based' ? sourceFile.content[key]["message"] : key,
+        source: sourceFile.type === 'key-based' ? sourceFile.content[key]["source"] : undefined,
       }));
 
     const unusedStrings = existingKeys.filter(

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -16,6 +16,7 @@ export interface TranslationResult {
 export interface TString {
   key: string;
   value: string;
+  source?: string;
 }
 export interface TranslationService {
   name: string;

--- a/src/services/openai.ts
+++ b/src/services/openai.ts
@@ -256,7 +256,7 @@ ISO to Language:
   }
 
   async translateStrings(
-    strings: { key: string; value: string }[],
+    strings: { key: string; value: string, source?: string }[],
     from: string,
     to: string,
   ): Promise<TranslationResult[]> {

--- a/src/util/file-system.ts
+++ b/src/util/file-system.ts
@@ -57,12 +57,7 @@ export const loadTranslations = (
         name: path.basename(f),
         originalContent: json,
         type,
-        content:
-          type === 'key-based'
-            ? flatten(require(path.resolve(directory, f)), {
-                safe: !withArrays,
-              })
-            : require(path.resolve(directory, f)),
+        content: require(path.resolve(directory, f)),
       } as TranslatableFile;
     });
 


### PR DESCRIPTION
- The current changes groups single worded strings based on the source
- It is only supported in DeepL
- The currently changes would break the functionalities for other json structure particularly nested ones

JSON structure for grouping single worded strings to work
```json
{
  "sdf": {
    "message": "Decline",
    "source": "Options"
  },
  "sdg": {
    "message": "Accept",
    "source": "Options"
  },
  "sdh": {
    "message": "Maybe",
    "source": "Options"
  },
  "sdu": {
    "message": "Time",
    "source": "Options"
  },
  "sdv": {
    "message": "Topic",
    "source": "Options"
  },
  "sdw": {
    "message": "Description",
    "source": "Options"
  },
  "sdo": {
    "message": "Yes",
    "source": "Other"
  },
  "sdx": {
    "message": "You can use {0} with your existing XMPP or Jabber account.",
    "source": "Other"
  }
}
```

Outputs
```json
{
  "sdf": "Ablehnen",
  "sdg": "Akzeptieren",
  "sdh": "Vielleicht",
  "sdo": "Ja",
  "sdu": "Zeit",
  "sdv": "Thema",
  "sdw": "Beschreibung",
  "sdx": "Sie können {0} mit Ihrem bestehenden XMPP- oder Jabber-Konto verwenden."
}
```