### PR TITLE
Context for translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,21 @@ You can select a matchers using the `-m` or `--matcher` option. If you specify
 the `--list-matchers` flag, json-autotranslate will output a list of all
 available matchers.
 
+## Context for strings
+
+Context for strings that need more context when tranlation but the for supported format is:
+
+```json
+{
+  "[id]": {
+    "string": "[message]",
+    "description": "[description]"
+  }
+}
+```
+
+Only DeepL and DeepL free are supported now.
+
 ## Available Options
 
 ```
@@ -320,6 +335,7 @@ Options:
   --decode-escapes                               decodes escaped HTML entities like &#39; into normal UTF-8 characters
   -o, --overwrite                                overwrite already present translations
   -h, --help                                     display help for command
+  --template <filename>                          template file that contains string and context for translation
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ available matchers.
 
 ## Context for strings
 
-Context for strings that need more context when tranlation but the for supported format is:
+Context for strings that need more context to translate but the for supported format is:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ available matchers.
 
 ## Context for strings
 
-Context for strings that need more context to translate but the for supported format is:
+Context for strings that need more context to translate but the supported format is:
 
 ```json
 {

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,6 +102,14 @@ commander
     '-o, --overwrite',
     'overwrite existing translations instead of skipping them',
   )
+  .option(
+    '--template <filename>',
+    'template file for translations',
+  )
+  .option(
+    '--context-field <fieldName>',
+    'field name in the template file that contains the context',
+  )
   .parse(process.argv);
 
 const translate = async (
@@ -122,6 +130,8 @@ const translate = async (
   appName?: string,
   context?: string,
   overwrite: boolean = false,
+  template?: string,
+  contextField?: string,
 ) => {
   const workingDir = path.resolve(process.cwd(), inputDir);
   const resolvedCacheDir = path.resolve(process.cwd(), cacheDir);
@@ -441,6 +451,8 @@ translate(
   commander.appName,
   commander.context,
   commander.overwrite,
+  commander.template,
+  commander.contextField,
 ).catch((e: Error) => {
   console.log();
   console.log(chalk.bgRed('An error has occurred:'));

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,10 +15,10 @@ import {
   getAvailableLanguages,
   fixSourceInconsistencies,
   evaluateFilePath,
+  loadTemplate,
   FileType,
   DirectoryStructure,
   TranslatableFile,
-  loadTemplate,
 } from './util/file-system';
 import { matcherMap } from './matchers';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,10 +107,6 @@ commander
     '--template <filename>',
     'template file for translations',
   )
-  .option(
-    '--context-field <fieldName>',
-    'field name in the template file that contains the context',
-  )
   .parse(process.argv);
 
 const translate = async (
@@ -132,7 +128,6 @@ const translate = async (
   context?: string,
   overwrite: boolean = false,
   template?: string,
-  contextField?: string,
 ) => {
   const workingDir = path.resolve(process.cwd(), inputDir);
   const resolvedCacheDir = path.resolve(process.cwd(), cacheDir);
@@ -455,7 +450,6 @@ translate(
   commander.context,
   commander.overwrite,
   commander.template,
-  commander.contextField,
 ).catch((e: Error) => {
   console.log();
   console.log(chalk.bgRed('An error has occurred:'));

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import {
   FileType,
   DirectoryStructure,
   TranslatableFile,
+  loadTemplate,
 } from './util/file-system';
 import { matcherMap } from './matchers';
 
@@ -156,6 +157,8 @@ const translate = async (
   }
 
   const translationService = serviceMap[service];
+
+  const templateFile = loadTemplate(path.join(workingDir, sourceLang, template as string));
 
   const templateFilePath = evaluateFilePath(
     workingDir,

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,7 @@ commander
   )
   .option(
     '--template <filename>',
-    'template file for translations',
+    'template file that contains string and context for translations',
   )
   .parse(process.argv);
 

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -48,6 +48,8 @@ export const serviceMap: {
   'openai': new OpenAITranslator(),
 };
 
+export const servicesWithContextSupport = ['deepl', 'deepl-free'];
+
 export interface DeepLGlossary {
   glossary_id: string;
   name: string;

--- a/src/util/file-system.ts
+++ b/src/util/file-system.ts
@@ -12,6 +12,7 @@ export interface TranslatableFile {
   originalContent: string;
   type: FileType;
   content: object;
+  isTemplate?: boolean;
 }
 
 export const getAvailableLanguages = (
@@ -116,18 +117,25 @@ export const evaluateFilePath = (
  * }
  * ```
  */
-export function loadTemplate(filePath: string) {
+export function loadTemplate(filePath: string, sourceFile: TranslatableFile) {
   let file = fs.readFileSync(filePath).toString();
   let json = JSON.parse(file);
+  let formattedJSON = {};
   for (let key in json) {
     let entries = Object.values(json[key]);
     if (!entries[0]) {
       throw new Error("Missing string");
     }
-    json[key] = {
+    formattedJSON[key] = {
       message: entries[0],
       description: entries[1] ?? "",
     };
   }
-  return json;
+  return {
+    name: sourceFile.name,
+    originalContent: JSON.stringify(json, null, 2) + "\n",
+    type: sourceFile.type,
+    content: formattedJSON,
+    isTemplate: true,
+  } as TranslatableFile;
 }

--- a/src/util/file-system.ts
+++ b/src/util/file-system.ts
@@ -103,3 +103,31 @@ export const evaluateFilePath = (
       return path.resolve(directory);
   }
 };
+
+/**
+ * Loads the strings from the template file
+ * Must be in the format
+ * ```json
+ * {
+ *   "[id]": {
+ *    "string": "[message]",
+ *    "description": "[description]"
+ *   }
+ * }
+ * ```
+ */
+export function loadTemplate(filePath: string) {
+  let file = fs.readFileSync(filePath).toString();
+  let json = JSON.parse(file);
+  for (let key in json) {
+    let entries = Object.values(json[key]);
+    if (!entries[0]) {
+      throw new Error("Missing string");
+    }
+    json[key] = {
+      message: entries[0],
+      description: entries[1] ?? "",
+    };
+  }
+  return json;
+}


### PR DESCRIPTION
Adds support for translating with context for each individual string if there's a `template.json` with a description of the string in the format:

```json
{
  "[id]": {
    "string": "[message]",
    "description": "[description]"
  }
}
```