### PR TITLE
DeepL: Fix errors for when description is null or an empty string

### DIFF
--- a/src/services/deepl.ts
+++ b/src/services/deepl.ts
@@ -278,7 +278,7 @@ export class DeepL implements TranslationService {
       cleaned = [replaceInterpolations(strings[0].value.message)]
     } else {
       cleaned = strings.map((s) =>
-        replaceInterpolations(s.value, this.interpolationMatcher),
+        replaceInterpolations(s.value.message, this.interpolationMatcher),
       );
     }
 

--- a/src/services/deepl.ts
+++ b/src/services/deepl.ts
@@ -278,7 +278,7 @@ export class DeepL implements TranslationService {
       cleaned = [replaceInterpolations(strings[0].value.message)]
     } else {
       cleaned = strings.map((s) =>
-        replaceInterpolations(s.value.message, this.interpolationMatcher),
+        replaceInterpolations(s.value.message ?? s.value, this.interpolationMatcher),
       );
     }
 


### PR DESCRIPTION
There was error where it was not falling back to another property name if that one didn't work. I missed that case while testing.

Tested cases now:

- Undefined description
- Defined description
- empty string description
- No template file

```
💬 Translating strings from en to ar...
├── Translating messages.json
An error has occurred:
input.charCodeAt is not a function
TypeError: input.charCodeAt is not a function
    at peg$parseargument (/home/runner/work/mustang/mustang/app/node_modules/messageformat-parser/parser.js:497:15)
    at peg$parsetoken (/home/runner/work/mustang/mustang/app/node_modules/messageformat-parser/parser.js:431:10)
    at peg$parsestart (/home/runner/work/mustang/mustang/app/node_modules/messageformat-parser/parser.js:419:10)
    at peg$parse (/home/runner/work/mustang/mustang/app/node_modules/messageformat-parser/parser.js:1969:16)
    at matchIcu (/home/runner/work/mustang/mustang/app/node_modules/mustang-autotranslate/lib/matchers/icu.js:29:52)
    at replaceInterpolations (/home/runner/work/mustang/mustang/app/node_modules/mustang-autotranslate/lib/matchers/index.js:18:26)
    at /home/runner/work/mustang/mustang/app/node_modules/mustang-autotranslate/lib/services/deepl.js:235:79
    at Array.map (<anonymous>)
    at DeepL.runTranslation (/home/runner/work/mustang/mustang/app/node_modules/mustang-autotranslate/lib/services/deepl.js:235:31)
    at DeepL.translateStrings (/home/runner/work/mustang/mustang/app/node_modules/mustang-autotranslate/lib/services/deepl.js:127:43)

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Error: Process completed with exit code 1.
```