### PR TITLE
Dynamic Decode Escapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,22 @@ structure will be transferred over to the translated files as well.
 }
 ```
 
+## HTML Handling
+
+### HTML Tags
+
+Strings are translated by translation servcies as HTML, therefore HTML elements are handled by defualt.
+
+### HTML Entities
+
+Since strings are handled as HTML, characters like `>` would sometimes be converted to `&gt;` by the translation service.
+
+There's a `decode-escapes` options which decodes escaped HTML entities like `&#39;` into normal UTF-8 characters. And there are 3 options:
+
+1. `true`
+2. `false` - the default option
+3. `dynamic` - which detects if there's any HTML tags present and if there is then escape because times not all strings are HTML.
+
 ## Available Services
 
 As of this release, json-autotranslate offers five services:
@@ -332,7 +348,7 @@ Options:
   -f, --fix-inconsistencies                      automatically fixes inconsistent key-value pairs by setting the value to the key
   -d, --delete-unused-strings                    deletes strings in translation files that don't exist in the template
   --directory-structure <default|ngx-translate>  the locale directory structure
-  --decode-escapes                               decodes escaped HTML entities like &#39; into normal UTF-8 characters
+  --decode-escapes <true|false|dynamic>          decodes escaped HTML entities like &#39; into normal UTF-8 characters
   -o, --overwrite                                overwrite already present translations
   -h, --help                                     display help for command
   --template <filename>                          template file that contains string and context for translation

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ There's a `decode-escapes` options which decodes escaped HTML entities like `&#3
 2. `false` - the default option
 3. `dynamic` - which detects if there's any HTML tags present and if there is then escape because times not all strings are HTML.
 
+Note: `dynamic` option only available for DeepL at the moment.
+
 ## Available Services
 
 As of this release, json-autotranslate offers five services:

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,7 +121,7 @@ const translate = async (
   fixInconsistencies = false,
   service: keyof typeof serviceMap = 'google-translate',
   matcher: keyof typeof matcherMap = 'icu',
-  decodeEscapes: boolean | string = false,
+  decodeEscapes: boolean | 'dynamic' = false,
   config?: string,
   glossariesDir?: string | boolean,
   appName?: string,
@@ -135,8 +135,8 @@ const translate = async (
   const targetLanguages = availableLanguages.filter((f) => f !== sourceLang);
 
   // Turn input into boolean
-  decodeEscapes = decodeEscapes == 'true' ? true : 
-                  decodeEscapes == 'false' ? false : decodeEscapes;
+  decodeEscapes = (decodeEscapes as string) == 'true' ? true : 
+                  (decodeEscapes as string) == 'false' ? false : decodeEscapes;
 
   if (!fs.existsSync(resolvedCacheDir)) {
     fs.mkdirSync(resolvedCacheDir);

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,7 +121,7 @@ const translate = async (
   fixInconsistencies = false,
   service: keyof typeof serviceMap = 'google-translate',
   matcher: keyof typeof matcherMap = 'icu',
-  decodeEscapes: boolean | "dynamic" = false,
+  decodeEscapes: boolean | string = false,
   config?: string,
   glossariesDir?: string | boolean,
   appName?: string,
@@ -133,6 +133,10 @@ const translate = async (
   const resolvedCacheDir = path.resolve(process.cwd(), cacheDir);
   const availableLanguages = getAvailableLanguages(workingDir, dirStructure);
   const targetLanguages = availableLanguages.filter((f) => f !== sourceLang);
+
+  // Turn input into boolean
+  decodeEscapes = decodeEscapes == 'true' ? true : 
+                  decodeEscapes == 'false' ? false : decodeEscapes;
 
   if (!fs.existsSync(resolvedCacheDir)) {
     fs.mkdirSync(resolvedCacheDir);

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ commander
     'the locale directory structure',
   )
   .option(
-    '--decode-escapes',
+    '--decode-escapes <true|false|dynamic>',
     'decodes escaped HTML entities like &#39; into normal UTF-8 characters',
   )
   .option(
@@ -121,7 +121,7 @@ const translate = async (
   fixInconsistencies = false,
   service: keyof typeof serviceMap = 'google-translate',
   matcher: keyof typeof matcherMap = 'icu',
-  decodeEscapes = false,
+  decodeEscapes: boolean | "dynamic" = false,
   config?: string,
   glossariesDir?: string | boolean,
   appName?: string,

--- a/src/services/amazon-translate.ts
+++ b/src/services/amazon-translate.ts
@@ -10,7 +10,7 @@ import fs from 'fs';
 export class AmazonTranslate implements TranslationService {
   private translate?: Translate;
   private interpolationMatcher?: Matcher;
-  private decodeEscapes?: boolean;
+  private decodeEscapes?: boolean | 'dynamic';
 
   private supportedLanguages = {
     af: 'af',
@@ -95,7 +95,7 @@ export class AmazonTranslate implements TranslationService {
   async initialize(
     config?: string,
     interpolationMatcher?: Matcher,
-    decodeEscapes?: boolean,
+    decodeEscapes?: boolean | 'dynamic',
   ) {
     const configJson = config
       ? JSON.parse(fs.readFileSync(config).toString())

--- a/src/services/azure-translator.ts
+++ b/src/services/azure-translator.ts
@@ -39,12 +39,12 @@ export class AzureTranslator implements TranslationService {
   private region?: string;
   private interpolationMatcher?: Matcher;
   private supportedLanguages?: Set<string>;
-  private decodeEscapes?: boolean;
+  private decodeEscapes?: boolean | 'dynamic';
 
   async initialize(
     config?: string,
     interpolationMatcher?: Matcher,
-    decodeEscapes?: boolean,
+    decodeEscapes?: boolean | 'dynamic',
   ) {
     const [apiKey, region] = config?.split(',') ?? [];
     if (!apiKey) throw new Error(`Please provide an API key for Azure.`);

--- a/src/services/deepl.ts
+++ b/src/services/deepl.ts
@@ -2,6 +2,7 @@ import { decode } from 'html-entities';
 import fetch from 'node-fetch';
 import * as path from 'path';
 import * as fs from 'fs';
+import { reHTMLTag } from '../util/html';
 
 import { TranslationService, TranslationResult, DeepLGlossary } from '.';
 import {
@@ -25,7 +26,7 @@ export class DeepL implements TranslationService {
   private supportedLanguages?: Set<string>;
   private formalityLanguages?: Set<string>;
   private interpolationMatcher?: Matcher;
-  private decodeEscapes?: boolean;
+  private decodeEscapes?: boolean | 'dynamic';
   private formality?: 'default' | 'less' | 'more';
 
   /**
@@ -45,7 +46,7 @@ export class DeepL implements TranslationService {
   async initialize(
     config?: string,
     interpolationMatcher?: Matcher,
-    decodeEscapes?: boolean,
+    decodeEscapes?: boolean | 'dynamic',
     glossariesDir?: string | boolean,
     appName?: string,
     context?: string,
@@ -362,7 +363,9 @@ export class DeepL implements TranslationService {
       result.push({
         key: string.key,
         value: string.value,
-        translated: this.decodeEscapes ? decode(t) : t,
+        translated: this.decodeEscapes == true ||
+          (this.decodeEscapes == "dynamic" && reHTMLTag.test(string.value))
+            ? decode(t) : t,
       });
     }
     return result;

--- a/src/services/deepl.ts
+++ b/src/services/deepl.ts
@@ -363,8 +363,8 @@ export class DeepL implements TranslationService {
       result.push({
         key: string.key,
         value: string.value,
-        translated: this.decodeEscapes == true ||
-          (this.decodeEscapes == "dynamic" && reHTMLTag.test(string.value))
+        translated: this.decodeEscapes === true ||
+          (this.decodeEscapes =="dynamic" && !reHTMLTag.test(string.value))
             ? decode(t) : t,
       });
     }

--- a/src/services/google-translate.ts
+++ b/src/services/google-translate.ts
@@ -17,7 +17,7 @@ export class GoogleTranslate implements TranslationService {
   private translate?: v2.Translate;
   private interpolationMatcher?: Matcher;
   private supportedLanguages: string[] = [];
-  private decodeEscapes?: boolean;
+  private decodeEscapes?: boolean | 'dynamic';
 
   public name = 'Google Translate';
 
@@ -32,7 +32,7 @@ export class GoogleTranslate implements TranslationService {
   async initialize(
     config?: string,
     interpolationMatcher?: Matcher,
-    decodeEscapes?: boolean,
+    decodeEscapes?: boolean | 'dynamic',
   ) {
     this.translate = new v2.Translate({
       autoRetry: true,

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -22,7 +22,7 @@ export interface TranslationService {
   initialize: (
     config?: string,
     interpolationMatcher?: Matcher,
-    decodeEscapes?: boolean,
+    decodeEscapes?: boolean | 'dynamic',
     glossariesDir?: string | boolean,
     appName?: string,
     context?: string,

--- a/src/services/openai.ts
+++ b/src/services/openai.ts
@@ -16,12 +16,12 @@ export class OpenAITranslator implements TranslationService {
   private systemPrompt?: string;
   private context?: { [key: string]: string };
   private interpolationMatcher?: Matcher;
-  private decodeEscapes?: boolean;
+  private decodeEscapes?: boolean | 'dynamic';
 
   async initialize(
     config?: string,
     interpolationMatcher?: Matcher,
-    decodeEscapes?: boolean,
+    decodeEscapes?: boolean | 'dynamic',
     glossariesDir?: string | boolean,
     appName?: string,
     context?: string,

--- a/src/util/html.ts
+++ b/src/util/html.ts
@@ -1,0 +1,1 @@
+export const reHTMLTag = /<\/?[a-z][\s\S]*>/i;

--- a/src/util/html.ts
+++ b/src/util/html.ts
@@ -1,1 +1,1 @@
-export const reHTMLTag = /<\/?[a-zA-Z]+[\s\S]*>/;
+export const reHTMLTag = /<\/?[a-zA-Z][\s\w\p{P}=]*>/u;

--- a/src/util/html.ts
+++ b/src/util/html.ts
@@ -1,1 +1,1 @@
-export const reHTMLTag = /<\/?[a-z][\s\S]*>/i;
+export const reHTMLTag = /<\/?[a-zA-Z]+[\s\S]*>/;


### PR DESCRIPTION
- All strings are handled as HTML therefore some characters are escaped to HTML entities e.g. `>` as `&lt;`
- There's a `--decode-escapes` option but it applies the rule to the entire translation file instead of the single string
- I've added a `dynamic` option which only decodes HTML entities if there's no HTML tag present in the string
- Only implemented for DeepL so far