### PR TITLE
DeepL: Add back off timer between retries

### DIFF
--- a/src/util/utils.ts
+++ b/src/util/utils.ts
@@ -1,0 +1,1 @@
+export const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));


### PR DESCRIPTION
- We were retrying requests without waiting between retries
- I've applied an backoff of `10 seconds` x 2 for each retry.
- The same [default settings](https://github.com/DeepLcom/deepl-node/blob/main/README.md#configuration) as the DeepL node client