### PR TITLE
DeepL: Send authKey in HTTP header

### DIFF
--- a/src/services/deepl.ts
+++ b/src/services/deepl.ts
@@ -79,10 +79,13 @@ export class DeepL implements TranslationService {
     }
 
     const url = new URL(`${this.apiEndpoint}/languages`);
-    url.searchParams.append('auth_key', this.apiKey);
     url.searchParams.append('type', 'target');
 
-    const response = await fetch(url.toString());
+    const response = await fetch(url.toString() , {
+      headers: {
+        Authorization: `DeepL-Auth-Key ${this.apiKey}`,
+      },
+    });
 
     if (!response.ok) {
       throw new Error('Could not fetch supported languages from DeepL');


### PR DESCRIPTION
- send authKey in HTTP header even for fetching languages `Authorization: DeepL-Auth-Key [yourAuthKey]`
- https://developers.deepl.com/docs/resources/breaking-changes-change-notices/november-2025-deprecation-of-legacy-auth-methods