### PR TITLE
Package: Compile package on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mustang-autotranslate",
   "description": "Translate a folder of JSON files containing translations into multiple languages.",
   "version": "1.16.1",
-  "main": "lib/index.js",
+  "main": "index.js",
   "license": "MIT",
   "scripts": {
     "start": "ts-node src/index.ts",

--- a/package.json
+++ b/package.json
@@ -2,12 +2,13 @@
   "name": "mustang-autotranslate",
   "description": "Translate a folder of JSON files containing translations into multiple languages.",
   "version": "1.16.1",
-  "main": "index.js",
+  "main": "lib/index.js",
   "license": "MIT",
   "scripts": {
     "start": "ts-node src/index.ts",
     "test": "jest",
     "build": "tsc",
+    "install": "tsc",
     "prepublishOnly": "tsc"
   },
   "author": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "ts-node src/index.ts",
     "test": "jest",
     "build": "tsc",
-    "install": "tsc",
+    "prepare": "npm run build",
     "prepublishOnly": "tsc"
   },
   "author": {


### PR DESCRIPTION
- Compile code on install, `prepare` runs after all dependencies are installed but also ensures the `bin` is registered in the `node_modules/.bin` directory