### PR TITLE
Don't overwrite translation if it's different from cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,8 @@ Options:
   -d, --delete-unused-strings                    deletes strings in translation files that don't exist in the template
   --directory-structure <default|ngx-translate>  the locale directory structure
   --decode-escapes <true|false|dynamic>          decodes escaped HTML entities like &#39; into normal UTF-8 characters
-  -o, --overwrite                                overwrite already present translations
+  -o, --overwrite                                overwrite all translations
+  --keep-manual                                  don't overwrite already present translations
   -h, --help                                     display help for command
   --template <filename>                          template file that contains string and context for translation
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,11 @@ commander
   )
   .option(
     '-o, --overwrite',
-    'overwrite existing translations instead of skipping them',
+    'overwrite all translations',
+  )
+  .option(
+    '--keep-manual',
+    'don\'t overwrite existing translations',
   )
   .option(
     '--template <filename>',
@@ -127,6 +131,7 @@ const translate = async (
   appName?: string,
   context?: string,
   overwrite: boolean = false,
+  keepManual: boolean = false,
   template?: string,
 ) => {
   const workingDir = path.resolve(process.cwd(), inputDir);
@@ -341,6 +346,7 @@ const translate = async (
       deleteUnusedStrings,
       withArrays,
       overwrite,
+      keepManual,
     );
 
     switch (dirStructure) {
@@ -473,6 +479,7 @@ translate(
   commander.appName,
   commander.context,
   commander.overwrite,
+  commander.keepManual,
   commander.template,
 ).catch((e: Error) => {
   console.log();
@@ -493,7 +500,8 @@ function createTranslator(
   dirStructure: DirectoryStructure,
   deleteUnusedStrings: boolean,
   withArrays: boolean,
-  overwrite,
+  overwrite: boolean,
+  keepManual: boolean,
 ) {
   return async (
     sourceFile: TranslatableFile,
@@ -525,7 +533,7 @@ function createTranslator(
         (key) =>
           overwrite ||
           !existingKeys.includes(key) ||
-          overwrite && cacheDiff.includes(key) ||
+          !keepManual && cacheDiff.includes(key) ||
           (typeof sourceFile.content[key] == 'string' &&
             !destinationFile?.content[key]),
       )

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,7 +135,7 @@ const translate = async (
   const targetLanguages = availableLanguages.filter((f) => f !== sourceLang);
 
   // Turn input into boolean
-  decodeEscapes = (decodeEscapes as string) == 'true' ? true : 
+  decodeEscapes = (decodeEscapes as string) == 'true' ? true :
                   (decodeEscapes as string) == 'false' ? false : decodeEscapes;
 
   if (!fs.existsSync(resolvedCacheDir)) {
@@ -156,7 +156,7 @@ const translate = async (
   }
 
   const translationService = serviceMap[service];
-  
+
   if (template) {
     if (!servicesWithContextSupport.includes(service as string)) {
       throw new Error(
@@ -525,7 +525,7 @@ function createTranslator(
         (key) =>
           overwrite ||
           !existingKeys.includes(key) ||
-          cacheDiff.includes(key) ||
+          overwrite && cacheDiff.includes(key) ||
           (typeof sourceFile.content[key] == 'string' &&
             !destinationFile?.content[key]),
       )


### PR DESCRIPTION
- The script was translating strings that were different from what was in `cache` which overwrites manual translations because it's different from what's in cache