### PR TITLE
DeepL: Better tag handling and better quality translations

### DIFF
--- a/src/services/deepl.ts
+++ b/src/services/deepl.ts
@@ -298,6 +298,11 @@ export class DeepL implements TranslationService {
       // set in order to indicate to DeepL that the interpolated strings that the matcher
       // replaced with `<span translate="no">${index}</span> should not be translated
       tag_handling: 'html',
+      // see https://developers.deepl.com/docs/xml-and-html-handling/tag-handling-v2
+      // use v2 for better tag handling
+      tag_handling_version: 'v2',
+      // use quality_optimized model for better translation quality
+      model_type: 'quality_optimized',
       // set to 1, because all newlines in the source text should be preserved
       split_sentences: '1',
     };


### PR DESCRIPTION
- Use the newer [`v2`](https://developers.deepl.com/docs/xml-and-html-handling/tag-handling-v2) tag handling, I didn't notice any difference from tests
- Use [`quality_optimized`](https://developers.deepl.com/api-reference/translate#param-model-type) for better quality translations but it will be slower, this gives noticeable better translations, we were using the default `latency_optimized` model